### PR TITLE
docs: Add privacy policy references to community documents

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 # Contributor Covenant Code of Conduct
 
+Please also review our [Privacy Policy](PrivacyPolicy.md) before participating in our community.
+
 ## Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in our

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # Contributing Guidelines
 
-We gratefully accept contributions from the community. Please take a moment to review this document and our [Code of Conduct](CODE_OF_CONDUCT.md) in order to make the contribution process efficient and pleasant for everyone involved.
+We gratefully accept contributions from the community. Please take a moment to review this document, our [Code of Conduct](CODE_OF_CONDUCT.md), and our [Privacy Policy](PrivacyPolicy.md) in order to make the contribution process efficient and pleasant for everyone involved.
 
 ## Bug Reports
 


### PR DESCRIPTION
- Add privacy policy reference in CODE_OF_CONDUCT.md
- Update CONTRIBUTING.md to include privacy policy link

<!--
SPDX-FileCopyrightText: 2023-2024 Sony Semiconductor Solutions Corporation

SPDX-License-Identifier: Apache-2.0
-->

<!-- Start badge -->
<!-- End badge -->

## What?

  This PR adds references to the Privacy Policy in two community documentation files:
  - CODE_OF_CONDUCT.md: Added a note at the beginning asking users to review the Privacy Policy before
  participating
  - CONTRIBUTING.md: Updated the introductory paragraph to include the Privacy Policy alongside the
  Code of Conduct

## Why?

  - Transparency: Contributors and community members should be aware of how their data is handled when
  participating in the project

