### PR TITLE
[ADI-3553] Clean up module if mmap error occured

### DIFF
--- a/src/libevp-agent/module_impl_obj.c
+++ b/src/libevp-agent/module_impl_obj.c
@@ -114,6 +114,9 @@ module_impl_obj_load(struct module *m, const struct Module *modspec)
 			return EINVAL;
 		}
 	} else if (ret != ENOENT) {
+		/* Cleaned up the module if some IO error occurs. */
+		plat_mod_fs_file_unlink(m);
+
 		/* some IO error in check_hash */
 		return ret;
 	}

--- a/src/libevp-agent/module_impl_obj.c
+++ b/src/libevp-agent/module_impl_obj.c
@@ -114,7 +114,7 @@ module_impl_obj_load(struct module *m, const struct Module *modspec)
 			return EINVAL;
 		}
 	} else if (ret != ENOENT) {
-		/* Cleaned up the module if some IO error occurs. */
+		/* Clean up the module if some IO error occurs. */
 		plat_mod_fs_file_unlink(m);
 
 		/* some IO error in check_hash */

--- a/src/libevp-agent/platform.c
+++ b/src/libevp-agent/platform.c
@@ -135,8 +135,8 @@ plat_mod_fs_file_mmap(struct module *module, const void **data, size_t *size,
 	struct stat sb;
 	if (fstat(fd, &sb) == -1) {
 		*error = errno;
-		xlog_error("%s: error on stat %s(%d): %d", __func__, filename,
-			   fd, *error);
+		xlog_error("%s: error on stat %s(%d): errno=%d", __func__,
+			   filename, fd, *error);
 		goto failure;
 	}
 
@@ -146,7 +146,7 @@ plat_mod_fs_file_mmap(struct module *module, const void **data, size_t *size,
 
 	if (addr == MAP_FAILED) {
 		*error = errno;
-		xlog_error("%s: error on mmap %s(%d): %d, st_size=%zu",
+		xlog_error("%s: error on mmap %s(%d): errno=%d, st_size=%zu",
 			   __func__, filename, fd, errno, sb.st_size);
 		goto failure;
 	}

--- a/src/libevp-agent/platform.c
+++ b/src/libevp-agent/platform.c
@@ -135,7 +135,8 @@ plat_mod_fs_file_mmap(struct module *module, const void **data, size_t *size,
 	struct stat sb;
 	if (fstat(fd, &sb) == -1) {
 		*error = errno;
-		xlog_error("%s: error on stat: %d", __func__, *error);
+		xlog_error("%s: error on stat %s(%d): %d", __func__, filename,
+			   fd, *error);
 		goto failure;
 	}
 
@@ -145,7 +146,8 @@ plat_mod_fs_file_mmap(struct module *module, const void **data, size_t *size,
 
 	if (addr == MAP_FAILED) {
 		*error = errno;
-		xlog_error("%s: error on mmap: %d", __func__, errno);
+		xlog_error("%s: error on mmap %s(%d): %d, st_size=%zu",
+			   __func__, filename, fd, errno, sb.st_size);
 		goto failure;
 	}
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023-2024 Sony Semiconductor Solutions Corporation

SPDX-License-Identifier: Apache-2.0
-->

<!-- Start badge -->
<!-- End badge -->

## What?

Clean up module if mmap error occured.

## Why?
When an error occurs with mmap, the module information remains, so I added a call to `plat_mod_fs_file_unlink()` to perform cleanup.
